### PR TITLE
fix simlink and fiddle url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # status-fiddle
 
-Online UI editor for status-react https://status-im.github.io
+Online UI editor for status-react https://status-im.github.io/fiddle/
 
 ## Setup
 
@@ -24,7 +24,7 @@ ln -s /Users/*/status-dev-folder/status-react/resources/icons /Users/*/status-de
 Make simlink to components  
 
 ```
-ln -s /Users/*/status-dev-folder/status-react/src/status_im/ui/components /Users/*/status-dev-folder/status-fiddle/cljs/status_im/ui/components
+ln -s /Users/*/status-dev-folder/status-react/src/status_im/ui/components /Users/*/status-dev-folder/status-fiddle/src/cljs/status_im/ui/components
 ```
 
 ### Installation:


### PR DESCRIPTION
found some small issues during build the repo.

Still got error while running `lein figwheel-repl`, but that is another issue.

```
Could not Analyze src/cljs/status_im/ui/components/list_selection.cljs
No such namespace: status-im.ui.components.react, could not locate status_im/ui/components/react.cljs, status_im/ui/components/react.cljc, or JavaScript source providing "status-im.ui.components.react" 
```