### PR TITLE
add key prop in a seq

### DIFF
--- a/src/cljs/status_fiddle/views.cljs
+++ b/src/cljs/status_fiddle/views.cljs
@@ -118,7 +118,7 @@
                   (re-frame/dispatch [:switch-device device]))}
    (map
      (fn [device]
-       [:option {:value (:id device)} (:phone-name device)])
+       [:option {:value (:id device) :key (:id device)} (:phone-name device)])
      devices/devices)])
 
 (defview main-panel []


### PR DESCRIPTION
Saw warning in console:

```
Warning: Every element in a seq should have a unique :key: ([:option {:value 0} "iPhone 6"] [:option {:value 1} "iPhone 4S/4"] [:option {:value 2} "iPhone 5S/5"] [:option {:value 3} "iPhone 6Plus/7/7Plus/8/8Plus"] [:option {:value 4} "iPhone X"] [:option {:value 5} "Galaxy S6"] [:option {:value 6} "Galaxy S8"] [:option {:value 7} "Android xlarge"] [:option {:value 8} "Android large"] [:option {:value 9} "Android normal"] [:option {:value 10} "Android small"])
 (in status_fiddle.views.device_chooser)
```

Should add `key` prop to fix it. After add `:key (:id device)` the warning disappeared.
I'm not familiar with closure script though, please make a suggestion if its not a propriate fix.